### PR TITLE
feature(types): support function type literals

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -525,7 +525,8 @@ public class DeclarationGenerator {
 
         @Override
         public Void caseFunctionType(FunctionType type) {
-          throw new IllegalArgumentException("unsupported " + type);
+          visitFunctionType(type, "=>");
+          return null;
         }
 
         @Override
@@ -599,6 +600,10 @@ public class DeclarationGenerator {
     }
 
     private void visitFunctionDeclaration(FunctionType ftype) {
+      visitFunctionType(ftype, ":");
+    }
+
+    private void visitFunctionType(FunctionType ftype, String separator) {
       emit("(");
       Iterator<Node> parameters = ftype.getParameters().iterator();
       char pName = 'a'; // let's hope for no more than 26 parameters...
@@ -620,7 +625,11 @@ public class DeclarationGenerator {
         }
       }
       emit(")");
-      visitTypeDeclaration(ftype.getReturnType());
+      JSType type = ftype.getReturnType();
+      if (type != null) {
+        emit(separator);
+        visitType(type);
+      }
     }
   }
 }

--- a/src/test/java/com/google/javascript/cl2dts/fn_params.js
+++ b/src/test/java/com/google/javascript/cl2dts/fn_params.js
@@ -1,26 +1,26 @@
 goog.provide("fn_params");
 
 /**
- * @param {string} a
- * @param {number=} opt_b
+ * @param {string} x
+ * @param {number=} opt_y
  * @return {number}
  */
-fn_params.optional = function(a, opt_b) {
+fn_params.optional = function(x, opt_y) {
   return 1;
 };
 
 /**
- * @param {string} a
- * @param {?number=} opt_b
+ * @param {string} x
+ * @param {?number=} opt_y
  * @return {number}
  */
-fn_params.optionalNullable = function(a, opt_b) {
+fn_params.optionalNullable = function(x, opt_y) {
   return 1;
 };
 
 /**
- * @param {string} a
- * @param {...number} b
+ * @param {string} x
+ * @param {...number} y
  */
-fn_params.varargs = function(a, b) {
+fn_params.varargs = function(x, y) {
 };

--- a/src/test/java/com/google/javascript/cl2dts/types.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types.d.ts
@@ -9,6 +9,7 @@ declare namespace ಠ_ಠ.cl2dts_internal.types {
     set (a : T ) : void ;
   }
   var f : Foo < string > ;
+  var g : (a : number , b : any ) => any ;
 }
 declare module 'goog:types' {
   import alias = ಠ_ಠ.cl2dts_internal.types;

--- a/src/test/java/com/google/javascript/cl2dts/types.js
+++ b/src/test/java/com/google/javascript/cl2dts/types.js
@@ -29,3 +29,6 @@ types.Foo.prototype.set = function(t) { };
 
 /** @type {types.Foo<string>} */
 types.f = new Foo();
+
+/** @type {null|function(number, ?):?} handler */
+types.g = null;

--- a/src/test/java/com/google/javascript/cl2dts/types_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_usage.ts
@@ -1,0 +1,3 @@
+///<reference path="./types"/>
+import {g} from 'goog:types';
+g(1, "something");


### PR DESCRIPTION
Also rename the parameters in `fn_params.js` to clarify that the names they are given in the .d.ts output have no relation to the names in the .js file