### PR TITLE
fix(bug): don't emit 'implements' when a superclass is the implementor

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -354,9 +354,9 @@ public class DeclarationGenerator {
           emit(getRelativeName(getSuperType(ftype)));
         }
 
-        if (ftype.hasImplementedInterfaces()) {
+        Iterator<ObjectType> it = ftype.getOwnImplementedInterfaces().iterator();
+        if (it.hasNext()) {
           emit("implements");
-          Iterator<ObjectType> it = ftype.getOwnImplementedInterfaces().iterator();
           while (it.hasNext()) {
             emit(getRelativeName(it.next()));
             if (it.hasNext()) {

--- a/src/test/java/com/google/javascript/cl2dts/multi_class.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/multi_class.d.ts
@@ -10,6 +10,8 @@ declare namespace ಠ_ಠ.cl2dts_internal.multi_class {
   }
   interface I2 extends I {
   }
+  class C extends B {
+  }
 }
 declare module 'goog:multi_class' {
   import alias = ಠ_ಠ.cl2dts_internal.multi_class;

--- a/src/test/java/com/google/javascript/cl2dts/multi_class.js
+++ b/src/test/java/com/google/javascript/cl2dts/multi_class.js
@@ -27,3 +27,9 @@ multi_class.I = function() {};
  * @extends {multi_class.I}
  */
 multi_class.I2 = function() {};
+
+/**
+ * @constructor
+ * @extends {multi_class.B}
+ */
+multi_class.C = function() {};


### PR DESCRIPTION
Found this bug while emitting .d.ts for `javascript/closure/ui/ac/autocomplete.js`