### PR TITLE
add support for tests with externs

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -575,7 +575,7 @@ public class DeclarationGenerator {
 
     private void visitRecordType(RecordType type) {
       emit("{");
-      Iterator<String> it = type.getPropertyNames().iterator();
+      Iterator<String> it = type.getOwnPropertyNames().iterator();
       while (it.hasNext()) {
         String propName = it.next();
         emit(propName);

--- a/src/test/java/com/google/javascript/cl2dts/DeclarationGeneratorTests.java
+++ b/src/test/java/com/google/javascript/cl2dts/DeclarationGeneratorTests.java
@@ -45,7 +45,7 @@ public class DeclarationGeneratorTests {
       File golden = getGoldenFile(input);
       final String inputText = getTestFileText(input);
       final String goldenText = getTestFileText(golden);
-      suite.addTest(new DeclarationTest(input.getName(), goldenText, inputText));
+      suite.addTest(new DeclarationTest(input.getName(), goldenText, inputText, input.getName().contains("_externs")));
     }
     return suite;
   }
@@ -73,18 +73,20 @@ public class DeclarationGeneratorTests {
     private final String testName;
     private final String goldenText;
     private final String inputText;
+    private final boolean withExterns;
 
-    private DeclarationTest(String testName, String goldenText, String inputText) {
+    private DeclarationTest(String testName, String goldenText, String inputText, boolean withExterns) {
       this.testName = testName;
       this.goldenText = goldenText;
       this.inputText = inputText;
+      this.withExterns = withExterns;
     }
 
     @Override
     public void run(TestResult result) {
       result.startTest(this);
       try {
-        assertThatProgram(inputText).generatesDeclarations(goldenText);
+        assertThatProgram(inputText).generatesDeclarations(withExterns, goldenText);
       } catch (Throwable t) {
         result.addError(this, t);
       } finally {

--- a/src/test/java/com/google/javascript/cl2dts/ProgramSubject.java
+++ b/src/test/java/com/google/javascript/cl2dts/ProgramSubject.java
@@ -32,8 +32,8 @@ class ProgramSubject extends Subject<ProgramSubject, ProgramSubject.Program> {
     super(failureStrategy, subject);
   }
 
-  public void generatesDeclarations(String... lines) {
-    DeclarationGenerator dct = new DeclarationGenerator(false);
+  public void generatesDeclarations(Boolean withExterns, String... lines) {
+    DeclarationGenerator dct = new DeclarationGenerator(withExterns);
     String actual = dct.generateDeclarations(getSubject().code);
     String expected = LINE_JOINER.join(lines);
     if (!actual.equals(expected)) {

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
@@ -1,0 +1,8 @@
+declare namespace ಠ_ಠ.cl2dts_internal.typesWithExterns {
+  function elementMaybe ( ) : Element ;
+  var a : { a : number } ;
+}
+declare module 'goog:typesWithExterns' {
+  import alias = ಠ_ಠ.cl2dts_internal.typesWithExterns;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
@@ -1,0 +1,12 @@
+goog.provide('typesWithExterns');
+
+
+/**
+ * @return {Element}
+ */
+typesWithExterns.elementMaybe = function() {return null};
+
+// browser externs extend the Object prototype with hasOwnProperty, etc. This tests that we
+// do not output them as TS will support them as part of lib.d.ts.
+/** @type {{a: number}} */
+typesWithExterns.a = {a: 3};

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs_usage.ts
@@ -1,0 +1,5 @@
+///<reference path="./types_with_externs.d.ts"/>
+
+import {elementMaybe} from 'goog:typesWithExterns';
+
+var el: Element = elementMaybe();


### PR DESCRIPTION
fixes attaching Object.prototype methods to object literal types when
externs are present.

Closes #18