### PR TITLE
implement type-var pair for Closure interfaces

### DIFF
--- a/src/test/java/com/google/javascript/cl2dts/interface.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/interface.d.ts
@@ -2,6 +2,7 @@ declare namespace ಠ_ಠ.cl2dts_internal {
   interface interface_exp {
     method ( ) : number ;
   }
+  var interface_exp : { staticMethod : ( ) => number , staticProp : number }
 }
 declare module 'goog:interface_exp' {
   import alias = ಠ_ಠ.cl2dts_internal.interface_exp;

--- a/src/test/java/com/google/javascript/cl2dts/interface.js
+++ b/src/test/java/com/google/javascript/cl2dts/interface.js
@@ -5,3 +5,9 @@ interface_exp = function() {};
 
 /** @return {number} */
 interface_exp.prototype.method = function() {};
+
+/** @return {number} */
+interface_exp.staticMethod = function() {return interface_exp.staticProp;};
+
+/** @type {number} */
+interface_exp.staticProp = 0;

--- a/src/test/java/com/google/javascript/cl2dts/interface_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/interface_usage.ts
@@ -3,3 +3,5 @@ import I from 'goog:interface_exp';
 class C implements I {
     method(): number { return 0; }
 }
+
+var a: number = I.staticMethod();


### PR DESCRIPTION
Unlike TS interfaces closure interfaces are allowed to have 'static'
methods and properties. In TS we split the closure interface into a TS
interface along with a record type declaration for a var.

Closes #45