### PR TITLE
fix(dict): emit the property access explicitly in @dict classes,

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -737,6 +737,11 @@ public class DeclarationGenerator {
       checkArgument(instanceType.isObject(), "expected an ObjectType for this, but got "
           + instanceType + " which is a " + instanceType.getClass().getSimpleName());
       visitProperties((ObjectType) instanceType, false);
+      // Bracket-style property access
+      if (type.isDict()) {
+        emit("[key: string]: any;");
+        emitBreak();
+      }
       // Methods.
       visitProperties(prototype, false);
       // Statics.

--- a/src/test/java/com/google/javascript/cl2dts/dict.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/dict.d.ts
@@ -2,8 +2,12 @@ declare namespace ಠ_ಠ.cl2dts_internal.dict {
   var untyped : {[key: string]: any} ;
   var typed : { a : ( ...a : any [] ) => any } ;
   class DictClass {
+    constructor (n : any ) ;
+    [key: string]: any;
+    foo ( ) : void ;
   }
   class ClassWithDottedProperties {
+    [key: string]: any;
     foo : number ;
   }
 }

--- a/src/test/java/com/google/javascript/cl2dts/dict.js
+++ b/src/test/java/com/google/javascript/cl2dts/dict.js
@@ -13,8 +13,10 @@ dict.untyped = {};
 dict.typed = {'a': function() {}};
 
 /** @dict @constructor */
-dict.DictClass = function() {};
-var obj1 = new dict.DictClass();
+dict.DictClass = function(n) {};
+dict.DictClass.prototype.foo = function() {};
+
+var obj1 = new dict.DictClass(123);
 
 /** @dict @constructor */
 dict.ClassWithDottedProperties = function() {};

--- a/src/test/java/com/google/javascript/cl2dts/dict_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/dict_usage.ts
@@ -1,7 +1,7 @@
 ///<reference path="./dict"/>
 import {DictClass, ClassWithDottedProperties} from 'goog:dict';
 
-var d = new DictClass();
+var d = new DictClass('123');
 var s: string = d['thing'];
 
 var c = new ClassWithDottedProperties();


### PR DESCRIPTION
even though the usage is allowed without it.

Fixes #82.