### PR TITLE
fix(interface): statics on interfaces emitted in a namespace.

### DIFF
--- a/src/test/java/com/google/javascript/cl2dts/interface.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/interface.d.ts
@@ -2,9 +2,23 @@ declare namespace ಠ_ಠ.cl2dts_internal {
   interface interface_exp {
     method ( ) : number ;
   }
-  var interface_exp : { staticMethod : ( ) => number , staticProp : number }
+}
+declare namespace ಠ_ಠ.cl2dts_internal.interface_exp {
+  var staticMethod : ( ) => number ;
+  var staticProp : number ;
 }
 declare module 'goog:interface_exp' {
   import alias = ಠ_ಠ.cl2dts_internal.interface_exp;
+  export default alias;
+}
+declare namespace ಠ_ಠ.cl2dts_internal.interface_exp {
+  type SomeEnum = number ;
+  var SomeEnum : {
+    A : SomeEnum ,
+    B : SomeEnum ,
+  };
+}
+declare module 'goog:interface_exp.SomeEnum' {
+  import alias = ಠ_ಠ.cl2dts_internal.interface_exp.SomeEnum;
   export default alias;
 }

--- a/src/test/java/com/google/javascript/cl2dts/interface.js
+++ b/src/test/java/com/google/javascript/cl2dts/interface.js
@@ -1,4 +1,5 @@
 goog.provide('interface_exp');
+goog.provide('interface_exp.SomeEnum');
 
 /** @interface */
 interface_exp = function() {};
@@ -11,3 +12,9 @@ interface_exp.staticMethod = function() {return interface_exp.staticProp;};
 
 /** @type {number} */
 interface_exp.staticProp = 0;
+
+/** @enum {number} */
+interface_exp.SomeEnum = {
+  A: 1,
+  B: 2
+};

--- a/src/test/java/com/google/javascript/cl2dts/interface_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/interface_usage.ts
@@ -1,7 +1,10 @@
 /// <reference path="./interface" />
 import I from 'goog:interface_exp';
+import E from 'goog:interface_exp.SomeEnum';
+
 class C implements I {
     method(): number { return 0; }
 }
 
 var a: number = I.staticMethod();
+var e: E = E.A;


### PR DESCRIPTION
We emit the static methods and variable in a namespace, instead of a var
union type, as done previously. That way we do not interfere with any
enums being output.

Closes #78