### PR TITLE
fix(enums): support cross-referenced enums

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -425,12 +425,19 @@ public class DeclarationGenerator {
     }
 
     private String getUnqualifiedName(TypedVar symbol) {
-      String qualifiedName = symbol.getName();
-      int dotIdx = qualifiedName.lastIndexOf('.');
+      return lastPart(symbol.getName());
+    }
+
+    private String getUnqualifiedName(JSType type) {
+      return lastPart(type.getDisplayName());
+    }
+
+    private String lastPart(String input) {
+      int dotIdx = input.lastIndexOf('.');
       if (dotIdx == -1) {
-        return qualifiedName;
+        return input;
       }
-      return qualifiedName.substring(dotIdx + 1, qualifiedName.length());
+      return input.substring(dotIdx + 1, input.length());
     }
 
     private void walk(TypedVar symbol, boolean isDefault) {
@@ -552,9 +559,10 @@ public class DeclarationGenerator {
       // type MyEnum = EnumValueType;
       // var MyEnum: {A: MyEnum, B: MyEnum, ...};
       // TODO(martinprobst): Special case number enums to map to plain TS enums?
-      visitTypeAlias(type.getElementsType().getPrimitiveType(), getRelativeName(type));
+      visitTypeAlias(type.getElementsType().getPrimitiveType(), getUnqualifiedName(type));
       emit("var");
-      emit(getRelativeName(type));
+      // TS `type` declarations accept only unqualified names.
+      emit(getUnqualifiedName(type));
       emit(": {");
       emitBreak();
       indent();

--- a/src/test/java/com/google/javascript/cl2dts/aliased_enum_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/aliased_enum_usage.ts
@@ -1,0 +1,9 @@
+/// <reference path="./aliased_enums"/>
+import Enum from 'goog:nested.bar.Enum';
+import EnumAlias from 'goog:nested.baz.Enum';
+
+var a: Enum = Enum.A;
+var a2: EnumAlias = EnumAlias.A;
+// Because the twp enums are just type aliases of the same underlying type, they are assignable to
+// each other. This matches Closure's semantics.
+a = a2;

--- a/src/test/java/com/google/javascript/cl2dts/aliased_enums.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/aliased_enums.d.ts
@@ -1,0 +1,20 @@
+declare namespace ಠ_ಠ.cl2dts_internal.nested.bar {
+  type Enum = number ;
+  var Enum : {
+    A : nested.baz.Enum ,
+  };
+}
+declare module 'goog:nested.bar.Enum' {
+  import alias = ಠ_ಠ.cl2dts_internal.nested.bar.Enum;
+  export default alias;
+}
+declare namespace ಠ_ಠ.cl2dts_internal.nested.baz {
+  type Enum = number ;
+  var Enum : {
+    A : Enum ,
+  };
+}
+declare module 'goog:nested.baz.Enum' {
+  import alias = ಠ_ಠ.cl2dts_internal.nested.baz.Enum;
+  export default alias;
+}

--- a/src/test/java/com/google/javascript/cl2dts/aliased_enums.js
+++ b/src/test/java/com/google/javascript/cl2dts/aliased_enums.js
@@ -1,0 +1,12 @@
+goog.provide('nested.baz.Enum');
+goog.provide('nested.bar.Enum');
+
+/** @enum */
+nested.baz.Enum = {
+  A: 1
+};
+
+// The output is only correct for enums with the same name.
+
+/** @enum */
+nested.bar.Enum = nested.baz.Enum;


### PR DESCRIPTION
Closure allows for the following 'enum-aliasing' syntax:

/** @enum */
foo.A = {...};

/** @enum */
foo.B = foo.A;

This commit generates correct output for that case.

Closes #77