### PR TITLE
Add support for Arguments and NodeList.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   runtime 'args4j:args4j:2.0.26'
   runtime 'com.google.code.gson:gson:2.3.1'
 
-  compile 'com.google.javascript:closure-compiler:v20150609'
+  compile 'com.google.javascript:closure-compiler:v20150901'
   compile 'com.google.guava:guava:18.0'
 
   testCompile 'junit:junit:4.11'

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
@@ -11,6 +11,10 @@ declare module 'goog:typesWithExterns.A' {
 declare namespace ಠ_ಠ.cl2dts_internal.typesWithExterns {
   function elementMaybe ( ) : Element ;
   var a : { a : number } ;
+  var b : IArguments ;
+  type ArrayLike = NodeList | IArguments | { length : number } ;
+  var c : NodeList | IArguments | { length : number } ;
+  function id (x : NodeList | IArguments | { length : number } ) : NodeList | IArguments | { length : number } ;
 }
 declare module 'goog:typesWithExterns' {
   import alias = ಠ_ಠ.cl2dts_internal.typesWithExterns;

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
@@ -3,6 +3,7 @@ goog.provide('typesWithExterns.A');
 goog.provide('typesWithExterns.B');
 goog.provide('typesWithExterns.C');
 
+
 /**
  * @return {Element}
  */
@@ -43,3 +44,47 @@ typesWithExterns.C = function() {
   typesWithExterns.A.apply(this, arguments);
 };
 goog.inherits(typesWithExterns.C, typesWithExterns.A);
+
+
+// NewArguments and NewNodeList are copied from an upstream es3.js extern
+// TODO(rado): upgrade closure compiler and remove them when released.
+
+/**
+ * @constructor
+ * @implements {IArrayLike<?>}
+ */
+function NewArguments() {}
+
+/**
+ * @type {number}
+ */
+NewArguments.prototype.length;
+
+/**
+ * @constructor
+ * @implements {IArrayLike<?>}
+ */
+function NewNodeList() {}
+
+/**
+ * @type {number}
+ */
+NewNodeList.prototype.length;
+
+
+/** @type {NewArguments} */
+typesWithExterns.b = null;
+
+/**
+ * @typedef {NewNodeList|NewArguments|{length: number}}
+ */
+typesWithExterns.ArrayLike;
+
+/** @type {typesWithExterns.ArrayLike} */
+typesWithExterns.c = null;
+
+/**
+ * @param {typesWithExterns.ArrayLike} x
+ * @returns {typesWithExterns.ArrayLike}
+ */
+typesWithExterns.id = function(x) { return x; }

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs_usage.ts
@@ -1,3 +1,4 @@
-import {elementMaybe} from 'goog:typesWithExterns';
+import {elementMaybe, id} from 'goog:typesWithExterns';
 
 var el: Element = elementMaybe();
+var els: ArrayLike<any> = id(document.getElementsByClassName('foo'));


### PR DESCRIPTION
Platform apis like Arguments and Nodelist need to be translated to
their corresponding apis in lib.d.ts

Upgrade closure to the newest released version.