### PR TITLE
fix dedups fields from prototype chain.

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -831,8 +831,8 @@ public class DeclarationGenerator {
         emit("[key: string]: any;");
         emitBreak();
       }
-      // Methods.
-      visitProperties(prototype, false);
+      // Prototype fields (mostly methods).
+      visitProperties(prototype, false, ((ObjectType) instanceType).getOwnPropertyNames());
       // Statics.
       if (processStatics) {
         visitProperties(type, true);
@@ -843,7 +843,13 @@ public class DeclarationGenerator {
     }
 
     private void visitProperties(ObjectType objType, boolean isStatic) {
+      visitProperties(objType, isStatic,  Collections.<String>emptySet());
+    }
+
+    private void visitProperties(ObjectType objType, boolean isStatic, Set<String> skipNames) {
       for (String propName : objType.getOwnPropertyNames()) {
+        if (skipNames.contains(propName)) continue;
+
         if ("prototype".equals(propName) || "superClass_".equals(propName)
             // constructors are handled in #visitObjectType
             || "constructor".equals(propName)) {

--- a/src/test/java/com/google/javascript/cl2dts/lends.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/lends.d.ts
@@ -1,0 +1,17 @@
+declare namespace ಠ_ಠ.cl2dts_internal.lends {
+  class A {
+    a : string ;
+    c : boolean ;
+    static b : number ;
+  }
+}
+declare module 'goog:lends.A' {
+  import alias = ಠ_ಠ.cl2dts_internal.lends.A;
+  export default alias;
+}
+declare namespace ಠ_ಠ.cl2dts_internal.lends {
+}
+declare module 'goog:lends' {
+  import alias = ಠ_ಠ.cl2dts_internal.lends;
+  export = alias;
+}

--- a/src/test/java/com/google/javascript/cl2dts/lends.js
+++ b/src/test/java/com/google/javascript/cl2dts/lends.js
@@ -1,0 +1,19 @@
+goog.provide('lends');
+goog.provide('lends.A');
+
+/**
+ * @constructor
+ */
+lends.A = function() {
+  /** @type {string} */
+  this.a = "";
+};
+
+goog.object.extend(lends.A, /** @lends {lends.A} */ {b: 1});
+
+// lends manages to avoid the deduping of fields, and as far as closure
+// is concerned there is a field a on the prototype and on the instance.
+// Also the presense of @lends extends the type signature of A.prototype.
+goog.object.extend(lends.A.prototype, /** @lends {lends.A.prototype} */ {a: 1, c: true});
+
+

--- a/src/test/java/com/google/javascript/cl2dts/lends_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/lends_usage.ts
@@ -1,0 +1,3 @@
+import A from "goog:lends.A";
+
+var a: A = new A();

--- a/src/test/java/com/google/javascript/cl2dts/provide_single_class.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/provide_single_class.d.ts
@@ -12,6 +12,7 @@ declare module 'goog:foo.bar.Baz.NestedEnum' {
 declare namespace ಠ_ಠ.cl2dts_internal.foo.bar {
   class Baz {
     field : string ;
+    avalue : number ;
     equals (b : Baz.NestedClass ) : boolean ;
     method (a : string ) : number ;
     static staticMethod (a : string ) : number ;

--- a/src/test/java/com/google/javascript/cl2dts/provide_single_class.js
+++ b/src/test/java/com/google/javascript/cl2dts/provide_single_class.js
@@ -6,6 +6,12 @@ goog.provide('foo.bar.Baz.NestedEnum');
 foo.bar.Baz = function() {
   /** @type {string} */
   this.field = 'a';
+  // Surprisingly, defining the same field on the prototype and in
+  // the constructor with different signatures doesn't throw a type error.
+  // The type of the prototype is preferred and as far as types are
+  // concerned `avalue` lives on the prototype object.
+  /** @type {string} */
+  this.avalue = 0;
 };
 
 /**
@@ -15,6 +21,11 @@ foo.bar.Baz = function() {
 foo.bar.Baz.staticMethod = function(a) {
   return Number(a)
 };
+
+/**
+ * @type {number}
+ */
+foo.bar.Baz.prototype.avalue = 0;
 
 /**
  * @param {string} a


### PR DESCRIPTION
It appears that @lends has a way to create duplicate fields.
Adds a verification that deduping is not needed if prototype fields
are just added (without @lends), but conservatively we always do
deduping.