### PR TITLE
fix: do not output private properties.

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -860,7 +860,7 @@ public class DeclarationGenerator {
         String qualifiedName = objType.getDisplayName() + "." + propName;
         if (provides.contains(qualifiedName)) {
           continue;
-        } else if (isPrivate(propertyType.getJSDocInfo())) {
+        } else if (isPrivate(objType.getOwnPropertyJSDocInfo(propName))) {
           continue;
         } else if (propertyType.isEnumType()) {
           // For now, we don't emit static enum properties. We theorize it should not be needed.

--- a/src/test/java/com/google/javascript/cl2dts/provide_single_class.js
+++ b/src/test/java/com/google/javascript/cl2dts/provide_single_class.js
@@ -12,6 +12,8 @@ foo.bar.Baz = function() {
   // concerned `avalue` lives on the prototype object.
   /** @type {string} */
   this.avalue = 0;
+  /** @private {number} */
+  this.hideMe_ = 0;
 };
 
 /**


### PR DESCRIPTION
Previously we were checking the visibility of the property type, but
the correct check uses the jsdoc of the property itself.