### PR TITLE
fix: Function type vars should not output as classes.

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -405,9 +405,10 @@ public class DeclarationGenerator {
         FunctionType ftype = (FunctionType) type;
 
         // Closure represents top-level functions as classes because they might be new-able.
+        // This happens through externs es3.js which has Function marked as constructor.
         // See https://github.com/angular/closure-to-dts/issues/90
-        boolean ordinaryFunctionAppearingAsClass = type.isConstructor()
-            && type.getJSDocInfo() != null && !type.getJSDocInfo().isConstructor();
+        boolean ordinaryFunctionAppearingAsClass = type.isConstructor() &&
+            type.getDisplayName().equals("Function");
 
         if (type.isOrdinaryFunction() || ordinaryFunctionAppearingAsClass) {
           emit("function");

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
@@ -15,6 +15,7 @@ declare namespace ಠ_ಠ.cl2dts_internal.typesWithExterns {
   type ArrayLike = NodeList | IArguments | { length : number } ;
   var c : NodeList | IArguments | { length : number } ;
   function id (x : NodeList | IArguments | { length : number } ) : NodeList | IArguments | { length : number } ;
+  function topLevelFunction ( ...a : any [] ) : any ;
 }
 declare module 'goog:typesWithExterns' {
   import alias = ಠ_ಠ.cl2dts_internal.typesWithExterns;

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
@@ -88,3 +88,8 @@ typesWithExterns.c = null;
  * @returns {typesWithExterns.ArrayLike}
  */
 typesWithExterns.id = function(x) { return x; }
+
+/**
+ * @type {!Function}
+ */
+typesWithExterns.topLevelFunction = function() {};


### PR DESCRIPTION
Previous attempts to fix this missed the fact that externs need to be
present to reproduce the bug.