### PR TITLE
fix: local Error class extending global Error class.

### DIFF
--- a/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
+++ b/src/main/java/com/google/javascript/cl2dts/DeclarationGenerator.java
@@ -594,6 +594,11 @@ public class DeclarationGenerator {
 
         @Override
         public Void caseObjectType(ObjectType type) {
+          if (type.getDisplayName() != null && type.getDisplayName().equals("Error")) {
+            // global Error is aliased as GlobalError in closure.lib.d.ts.
+            emit("GlobalError");
+            return null;
+          }
           // Closure doesn't require that all the type params be declared, but TS does
           if (!type.getTemplateTypeMap().isEmpty()
               && !typeRegistry.getNativeType(OBJECT_TYPE).equals(type)) {

--- a/src/resources/closure.lib.d.ts
+++ b/src/resources/closure.lib.d.ts
@@ -1,0 +1,7 @@
+// Work around for https://github.com/Microsoft/TypeScript/issues/983
+// All Cl2dts namespaces are below ಠ_ಠ.cl2dts_internal, thus
+// this acts as global.
+declare namespace ಠ_ಠ.cl2dts_internal {
+  type GlobalError = Error;
+  var GlobalError: ErrorConstructor;
+}

--- a/src/test/java/com/google/javascript/cl2dts/DeclarationSyntaxTest.java
+++ b/src/test/java/com/google/javascript/cl2dts/DeclarationSyntaxTest.java
@@ -48,6 +48,7 @@ public class DeclarationSyntaxTest {
 
     final List<String> tscCommand =
         Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck");
+    tscCommand.add("src/resources/closure.lib.d.ts");
     tscCommand.addAll(goldenFilePaths);
     runChecked(tscCommand);
   }
@@ -57,6 +58,7 @@ public class DeclarationSyntaxTest {
     List<File> inputs = DeclarationGeneratorTests.getTestInputFiles(TS_SOURCES);
     final List<String> tscCommand =
         Lists.newArrayList(TSC.toString(), "--noEmit", "--skipDefaultLibCheck", "-m", "commonjs");
+    tscCommand.add("src/resources/closure.lib.d.ts");
     for (File input : inputs) {
       tscCommand.add(input.getPath());
     }

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.d.ts
@@ -18,6 +18,8 @@ declare namespace ಠ_ಠ.cl2dts_internal.typesWithExterns {
   function topLevelFunction ( ...a : any [] ) : any ;
   interface ExtendsIThenable extends PromiseLike < any > {
   }
+  class Error extends GlobalError {
+  }
 }
 declare module 'goog:typesWithExterns' {
   import alias = ಠ_ಠ.cl2dts_internal.typesWithExterns;

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs.js
@@ -99,3 +99,9 @@ typesWithExterns.topLevelFunction = function() {};
  * @extends {IThenable}
  */
 typesWithExterns.ExtendsIThenable = function() {};
+
+/**
+ * @constructor
+ * @extends {Error}
+ */
+typesWithExterns.Error = function() {};

--- a/src/test/java/com/google/javascript/cl2dts/types_with_externs_usage.ts
+++ b/src/test/java/com/google/javascript/cl2dts/types_with_externs_usage.ts
@@ -1,4 +1,6 @@
-import {elementMaybe, id} from 'goog:typesWithExterns';
+import {elementMaybe, id, Error} from 'goog:typesWithExterns';
 
 var el: Element = elementMaybe();
 var els: ArrayLike<any> = id(document.getElementsByClassName('foo'));
+
+var myError: Error = new Error();


### PR DESCRIPTION
Introduces an auxillary .d.ts `closure.lib.d.ts` that needs to be
passed into all consumers of cl2dts.

Closes #81